### PR TITLE
migrate from md5+sha256 to argon2

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,3 +11,14 @@
 - Start the app `./start.sh`, you should see your ngrok tunnel domain, open that in a LOCAL terminal (not in the devcontainer)
 - Reinstall app if needed (https://your-ngrok-domain.com/auth/slack)
 - Profit
+
+# Design
+
+## Store a Secret
+
+Slack calls POST /slash with payload containing the user's secret payload -> Generate a secretID (This becomes the key that the user will use to retrieve it later) -> We encrypt their secret using the secretID -> Hash their secretID -> store hashed secretID and encrypted secret in the db -> Send response to slack containing the 'envelope' button message containing the secretID as the callback_id
+
+## Retrieve a Secret
+
+User clicks the 'envelope' button in Slack -> Slack calls POST /interactive with the callback_id that was associated to this secret (which is a secretID) -> We hash the secretID to check the database for a matching secret -> Retrieve encrypted payload from database -> Decrypt payload with the secretID -> Return to user -> Delete secret from database
+

--- a/pkg/secretmessage/crypto.go
+++ b/pkg/secretmessage/crypto.go
@@ -103,11 +103,12 @@ func decrypt(input string, passphrase string) (string, error) {
 
 // encrypt wraps encryptWithReader
 func encrypt(input string, passphrase string) (string, error) {
-	return encryptWithReader(rand.Reader, input, passphrase)
+
+	return encryptWithReader(rand.Reader, input, passphrase, rand.Text())
 }
 
 // encryptWithReader takes an input string and passphrase and returns a hex-encoded encrypted string
-func encryptWithReader(rr io.Reader, input string, passphrase string) (string, error) {
+func encryptWithReader(rr io.Reader, input string, passphrase string, salt string) (string, error) {
 	var result string
 	if input == "" {
 		return result, fmt.Errorf("cannot encrypt empty string")
@@ -115,7 +116,6 @@ func encryptWithReader(rr io.Reader, input string, passphrase string) (string, e
 	if passphrase == "" {
 		return result, fmt.Errorf("cannot encrypt with empty passphrase")
 	}
-	salt := rand.Text()
 	key := deriveCryptoKeyV2(passphrase, salt)
 	c, err := aes.NewCipher(key)
 	if err != nil {

--- a/pkg/secretmessage/crypto.go
+++ b/pkg/secretmessage/crypto.go
@@ -10,19 +10,48 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"unicode/utf8"
+
+	"golang.org/x/crypto/argon2"
 )
 
+// v2$<salt>$<ciphertext>
+// |    |        |
+// |    |        hex-encoded encrypted payload
+// |    |
+// |    salt rand.Text()
+// |
+// version identifier
+var V2EncryptionRegExp = regexp.MustCompile(`^v2\$([a-zA-Z0-9]+)\$([a-fA-F0-9]+)$`)
+
+const Pepper string = "XP47CYQ5SWBR2ZUFPUFROF55PR"
+
+// secureSecretID takes a string and returns a deterministic argon2 hash with a fixed system-wide salt
+// to be used for generating the hashed secretID we store in the database
+func secureSecretID(input string) string {
+	return hex.EncodeToString(argon2.IDKey([]byte(input), []byte(Pepper), 1, 64*1024, 1, 32))
+}
+
+// hash returns a sha256 hash of a given input in hex encoding
 func hash(s string) string {
 	hashBytes := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(hashBytes[:])
 }
 
-func deriveCryptoKey(key string) []byte {
+// deriveCryptoKey takes a passphrase and returns a 16 byte slice which can be passed as an input to aes encrypt
+func deriveCryptoKey(passphrase string) []byte {
 	hasher := md5.New()
-	hasher.Write([]byte(key))
+	hasher.Write([]byte(passphrase))
 	return hasher.Sum(nil)
 }
+
+// deriveCryptoKeyV2 takes a passphrase and returns a 32 byte slice which can be used as an encryption key
+func deriveCryptoKeyV2(passphrase string, salt string) []byte {
+	return argon2.IDKey([]byte(passphrase), []byte(salt), 1, 64*1024, 1, 32)
+}
+
+// decrypt takes a hex-encoded input and passphrase and returns a decrypted string in plaintext
 func decrypt(input string, passphrase string) (string, error) {
 	var result string
 	if input == "" {
@@ -32,7 +61,20 @@ func decrypt(input string, passphrase string) (string, error) {
 		return result, fmt.Errorf("cannot decrypt with empty passphrase")
 	}
 
-	key := deriveCryptoKey(passphrase)
+	var key []byte
+
+	// If our encrypted string was prefaced with v2$ that means we encrypted with new v2 format
+	if V2EncryptionRegExp.MatchString(input) {
+		matches := V2EncryptionRegExp.FindStringSubmatch(input)
+		// extract the salt from first capture group
+		salt := matches[1]
+		// actual payload to decrypt (v2 prefix and salt removed)
+		input = matches[2]
+		key = deriveCryptoKeyV2(passphrase, salt)
+	} else {
+		key = deriveCryptoKey(passphrase)
+	}
+
 	ciphertext, err := hex.DecodeString(input)
 	if err != nil {
 		return result, err
@@ -59,10 +101,12 @@ func decrypt(input string, passphrase string) (string, error) {
 	return result, nil
 }
 
+// encrypt wraps encryptWithReader
 func encrypt(input string, passphrase string) (string, error) {
 	return encryptWithReader(rand.Reader, input, passphrase)
 }
 
+// encryptWithReader takes an input string and passphrase and returns a hex-encoded encrypted string
 func encryptWithReader(rr io.Reader, input string, passphrase string) (string, error) {
 	var result string
 	if input == "" {
@@ -71,7 +115,8 @@ func encryptWithReader(rr io.Reader, input string, passphrase string) (string, e
 	if passphrase == "" {
 		return result, fmt.Errorf("cannot encrypt with empty passphrase")
 	}
-	key := deriveCryptoKey(passphrase)
+	salt := rand.Text()
+	key := deriveCryptoKeyV2(passphrase, salt)
 	c, err := aes.NewCipher(key)
 	if err != nil {
 		return result, err
@@ -86,5 +131,5 @@ func encryptWithReader(rr io.Reader, input string, passphrase string) (string, e
 		return result, err
 	}
 	ciphertext := hex.EncodeToString(gcm.Seal(nonce, nonce, []byte(input), nil))
-	return ciphertext, nil
+	return fmt.Sprintf("v2$%s$%s", salt, ciphertext), nil
 }

--- a/pkg/secretmessage/crypto_test.go
+++ b/pkg/secretmessage/crypto_test.go
@@ -2,7 +2,6 @@ package secretmessage
 
 import (
 	"bytes"
-	"encoding/hex"
 	"io"
 	"reflect"
 	"testing"
@@ -34,11 +33,36 @@ func Test_hash(t *testing.T) {
 	}
 }
 
+func Test_secureSecretID(t *testing.T) {
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "should return argon2 hash as hex",
+			args: args{
+				s: "my input string",
+			},
+			want: "268aa12ad29ed592c4e73e727fc2152bb5f1edf343c61a9f5bf00d0c14b0a572",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secureSecretID(tt.args.s); got != tt.want {
+				t.Errorf("secureSecretID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_deriveCryptoKey(t *testing.T) {
 	type args struct {
 		key string
 	}
-	w, _ := hex.DecodeString("8af774dc91d8be77e2baccfb8856c103")
 	tests := []struct {
 		name string
 		args args
@@ -49,13 +73,41 @@ func Test_deriveCryptoKey(t *testing.T) {
 			args: args{
 				key: "my input string",
 			},
-			want: w,
+			want: []byte{138, 247, 116, 220, 145, 216, 190, 119, 226, 186, 204, 251, 136, 86, 193, 3},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := deriveCryptoKey(tt.args.key); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("deriveCryptoKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func Test_deriveCryptoKeyV2(t *testing.T) {
+	type args struct {
+		key  string
+		salt string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want []byte
+	}{
+		{
+			name: "should return argon2 byte slice",
+			args: args{
+				key:  "my input string",
+				salt: "DZNUVLZNJVR3HOWSZPM2DEEKQ3",
+			},
+			want: []byte{86, 190, 230, 34, 101, 60, 153, 105, 175, 164, 186, 225, 142, 50, 228, 245, 103, 115, 222, 104, 57, 160, 91, 32, 64, 134, 165, 228, 139, 67, 11, 173},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := deriveCryptoKeyV2(tt.args.key, tt.args.salt); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deriveCryptoKeyV2() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -77,11 +129,11 @@ func Test_encryptWithReader(t *testing.T) {
 		{
 			name: "successful encryption",
 			args: args{
-				rr:         bytes.NewReader([]byte("0000000000000000")),
+				rr:         bytes.NewReader([]byte("00000000000000000000000000000000")),
 				input:      "the password is baseball123",
 				passphrase: "monkey",
 			},
-			want: "30303030303030303030303029c9922a9be75ba2e6be5afd32d19387baea51fa577c0c51dc9809a54adb9085490f109237d15a3262a585",
+			want: "v2$303030303030303030303030c2dfaa69afd91914a32ff6456e66736ce2939c76ac82c607cf06248a1a85ade9b526af3b6329dc50931337",
 		},
 	}
 	for _, tt := range tests {
@@ -110,9 +162,17 @@ func Test_decrypt(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "successful decryption",
+			name: "successful decryption V1",
 			args: args{
 				input:      "30303030303030303030303029c9922a9be75ba2e6be5afd32d19387baea51fa577c0c51dc9809a54adb9085490f109237d15a3262a585",
+				passphrase: "monkey",
+			},
+			want: "the password is baseball123",
+		},
+		{
+			name: "successful decryption V2",
+			args: args{
+				input:      "v2$303030303030303030303030c2dfaa69afd91914a32ff6456e66736ce2939c76ac82c607cf06248a1a85ade9b526af3b6329dc50931337",
 				passphrase: "monkey",
 			},
 			want: "the password is baseball123",

--- a/pkg/secretmessage/crypto_test.go
+++ b/pkg/secretmessage/crypto_test.go
@@ -119,6 +119,7 @@ func Test_encryptWithReader(t *testing.T) {
 		rr         io.Reader
 		input      string
 		passphrase string
+		salt       string
 	}
 	tests := []struct {
 		name    string
@@ -127,18 +128,19 @@ func Test_encryptWithReader(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "successful encryption",
+			name: "successful encryption with salt",
 			args: args{
 				rr:         bytes.NewReader([]byte("00000000000000000000000000000000")),
 				input:      "the password is baseball123",
 				passphrase: "monkey",
+				salt:       "VC4TZT7JZOAAVFQ3F3N7GXF2RP",
 			},
-			want: "v2$303030303030303030303030c2dfaa69afd91914a32ff6456e66736ce2939c76ac82c607cf06248a1a85ade9b526af3b6329dc50931337",
+			want: "v2$VC4TZT7JZOAAVFQ3F3N7GXF2RP$303030303030303030303030a091fd029ae527dfa9ed207ba09c537d8bdb5012f264f2a65d68a333fd58b378e5791a94d3060e919d4486",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := encryptWithReader(tt.args.rr, tt.args.input, tt.args.passphrase)
+			got, err := encryptWithReader(tt.args.rr, tt.args.input, tt.args.passphrase, tt.args.salt)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("encrypt() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -172,7 +174,7 @@ func Test_decrypt(t *testing.T) {
 		{
 			name: "successful decryption V2",
 			args: args{
-				input:      "v2$303030303030303030303030c2dfaa69afd91914a32ff6456e66736ce2939c76ac82c607cf06248a1a85ade9b526af3b6329dc50931337",
+				input:      "v2$VC4TZT7JZOAAVFQ3F3N7GXF2RP$303030303030303030303030a091fd029ae527dfa9ed207ba09c537d8bdb5012f264f2a65d68a333fd58b378e5791a94d3060e919d4486",
 				passphrase: "monkey",
 			},
 			want: "the password is baseball123",

--- a/pkg/secretmessage/handle_slash_test.go
+++ b/pkg/secretmessage/handle_slash_test.go
@@ -94,7 +94,7 @@ var _ = Describe("/secret", func() {
 			var s secretmessage.Secret
 			gdb.Take(&s)
 			Expect(s.ID).To(MatchRegexp(`^[a-f0-9]{64}$`))
-			Expect(s.Value).To(MatchRegexp(`^[a-f0-9]{1,}$`))
+			Expect(s.Value).To(MatchRegexp(`^v2\$[A-Z0-9]{1,}\$[a-f0-9]{1,}$`))
 		})
 	})
 

--- a/pkg/secretmessage/slash.go
+++ b/pkg/secretmessage/slash.go
@@ -28,7 +28,7 @@ func PrepareAndSendSecretEnvelope(ctl *PublicController, c *gin.Context, secretT
 		return encryptErr
 	}
 
-	sec := NewSecret(hash(secretID), secretEncrypted, options...)
+	sec := NewSecret(secureSecretID(secretID), secretEncrypted, options...)
 	// Store the secret
 	storeErr := ctl.db.WithContext(hc).Create(sec).Error
 


### PR DESCRIPTION
Previously:
- We were storing `sha256(rawSecretID` as the identifier in the DB
- We were deriving an encryption key by taking `md5(rawSecretID`
- When redeeming a secret, clients would pass in rawSecretID (i.e. their passphrase AND identifier), we perform a sha256 to look it up, then we derive the key to use to decrypt it by md5-ing it.

Now:
- We generate a more secure hash of the rawSecretID by doing a deterministic argonv2 hash with a system-wide salt `argonv2(rawSecretID, fixed-salt)`. We store this in the DB, and it is possible to look up the DB key if we know the raw secret ID (which is the only thing the clients give us)
- We derive an encryption key using a random salt and argonv2 `argonv2(rawSecretID, random-salt`. We store the random salt in the DB as well as we need it derive the decryption key later. DB record effectively looks like the following:

| ID | Value |
|--------|--------|
| argonv2(secretID, fixedSalt) | `v2$<randomSalt>$<encryptedData>` |

- We still maintain backwards-compatibility to be able to lookup and decrypt an old secret - this can be removed once we confirm all existing secrets have expired or been redeemed.